### PR TITLE
Add more expected test cases for ls implementations

### DIFF
--- a/implement-shell-tools/ls/README.md
+++ b/implement-shell-tools/ls/README.md
@@ -6,6 +6,9 @@ Your task is to implement your own version of `ls`.
 
 It must act the same as `ls` would, if run from the directory containing this README.md file, for the following command lines:
 
+* `ls sample-files`
+* `ls sample-files/1.txt`
+* `ls sample-files/*`
 * `ls -1`
 * `ls -1 sample-files`
 * `ls -1 -a sample-files`

--- a/implement-shell-tools/wc/README.md
+++ b/implement-shell-tools/wc/README.md
@@ -11,6 +11,8 @@ It must act the same as `wc` would, if run from the directory containing this RE
 * `wc -w sample-files/3.txt`
 * `wc -c sample-files/3.txt`
 * `wc -l sample-files/*`
+* `wc -w -l sample-files/3.txt`
+* `wc -w -l sample-files/*`
 
 Matching any additional behaviours or flags are optional stretch goals.
 


### PR DESCRIPTION
Some trainees are doing a bit less than I was expecting when originally setting this.

Not to be merged util the current cohort have completed Module-Tools.